### PR TITLE
Update ios target configuration with shortcut

### DIFF
--- a/src/main/kotlin/KotlinMultiplatformExtensionExt.kt
+++ b/src/main/kotlin/KotlinMultiplatformExtensionExt.kt
@@ -4,23 +4,20 @@
 
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 fun Project.setupFramework(
     exports: List<KotlinNativeExportable>
 ) {
-    val configureIos: KotlinNativeTarget.() -> Unit = {
-        binaries {
-            framework("MultiPlatformLibrary") {
-                freeCompilerArgs += "-Xobjc-generics"
-
-                exports.forEach { it.export(project, this) }
-            }
-        }
-    }
 
     extensions.findByType(KotlinMultiplatformExtension::class.java)?.run {
-        iosArm64("iosArm64", configureIos)
-        iosX64("iosX64", configureIos)
+        ios {
+            binaries {
+                framework("MultiPlatformLibrary") {
+                    freeCompilerArgs += "-Xobjc-generics"
+
+                    exports.forEach { it.export(project, this) }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The `ios` shortcut creates targets for iosArm64 and iosX64 while also
creating an intermediate source set of iosMain. Manually configuring
iosArm64 and iosX64 is no longer required as of 1.3.60.

Signed-off-by: Nicholas J Halase <nhalase@thumbcat.io>