### PR TITLE
custom framework name

### DIFF
--- a/src/main/kotlin/KotlinMultiplatformExtensionExt.kt
+++ b/src/main/kotlin/KotlinMultiplatformExtensionExt.kt
@@ -7,11 +7,12 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 fun Project.setupFramework(
-    exports: List<KotlinNativeExportable>
+    exports: List<KotlinNativeExportable>,
+    name: String = "MultiPlatformLibrary"
 ) {
     val configureIos: KotlinNativeTarget.() -> Unit = {
         binaries {
-            framework("MultiPlatformLibrary") {
+            framework(name) {
                 freeCompilerArgs += "-Xobjc-generics"
 
                 exports.forEach { it.export(project, this) }


### PR DESCRIPTION
Sometimes it may be needed to use some multiplatform libraries in iOS Application, and, as I understand, Swift doesn't allow us to import some frameworks with the same name. It will be useful to add an optional parameter with the default value to setupFramework method.